### PR TITLE
Add apiVersion config to client

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "printWidth": 100,
   "singleQuote": true,
-  "semi": false
+  "semi": false,
+  "bracketSpacing": true
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react'
-import client from 'part:@sanity/base/client'
+import sanityClient from 'part:@sanity/base/client'
 import { parseISO, isAfter } from 'date-fns'
 import config from 'config:content-calendar'
 import delve from 'dlv'
 
 const DEFAULT_TITLE = 'Untitled?'
+
+const client = sanityClient.withConfig({ apiVersion: '2020-03-25' })
 
 export const useEvents = () => {
   const [events, setEvents] = useState([])


### PR DESCRIPTION
The version of the api is not the latest one as on the latest one the query we use is slow (~6s). So this is just to stop the deprecation warning from happening

Fixes #9 

I added a rule to `.prettierrc` as the formatting of the code suggested that you are using the bracket spacing but the config didn't have it, so my code was messing up the formatting and creating more changes that are not relevant to this PR.