### PR TITLE
add hideWarnings config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Create or open the config file found in `config/content-calendar.json`. The file
       "timeFormat": "hh:mm a",
       "showAuthor": "false"
     }
-  }
+  },
+  "hideWarnings": false
 }
 ```
 
@@ -59,6 +60,8 @@ In the configuration values, you can also modify how the dates and times are for
 
 > Note: the type.field option signals when this post should be scheduled to release, this requires us to add a "date" or "datetime" field to the document you want to enable
 > scheduling for.
+
+`hideWarnings` may be useful if your Publishing method does not involve scheduling a specific Document Revision. By default Warnings will show if a Document has been edited after it was originally Scheduled – and before it has been Published.
 
 ### Installing with other custom document actions
 

--- a/config.dist.json
+++ b/config.dist.json
@@ -1,3 +1,4 @@
 {
-    "types": []
+    "types": [],
+    "hideWarnings": false
 }

--- a/src/AgendaEvent.js
+++ b/src/AgendaEvent.js
@@ -5,7 +5,7 @@ import schema from 'part:@sanity/base/schema'
 import { format } from 'date-fns'
 import User from './User'
 import styles from './AgendaEvent.css'
-import { dateFormat, timeFormat, showAuthor } from './config'
+import { dateFormat, timeFormat, showAuthor, hideWarnings } from './config'
 import IntentButton from 'part:@sanity/components/buttons/intent'
 import HistoryIcon from 'part:@sanity/base/history-icon'
 import EditIcon from 'part:@sanity/base/edit-icon'
@@ -13,6 +13,7 @@ import Warning from './Warning'
 import { getPublishedId } from 'part:@sanity/base/util/draft-utils'
 
 export default function AgendaEvent({ event }) {
+  console.log({hideWarnings})
   const hasDraft = useHasChanges(event)
   const publishedId = getPublishedId(event.doc._id || '')
   return (
@@ -38,7 +39,7 @@ export default function AgendaEvent({ event }) {
           </div>
         </div>
         <div className={styles.actionsWrapper}>
-          {hasDraft && (
+          {hasDraft && !hideWarnings && (
             <div className={styles.warning}>
               <Warning />
             </div>

--- a/src/Event.js
+++ b/src/Event.js
@@ -3,14 +3,14 @@ import styles from './Event.css'
 import { useHasChanges } from './hooks'
 import WarningIcon from 'part:@sanity/base/warning-icon'
 import { format } from 'date-fns'
-import { timeFormat } from './config'
+import { hideWarnings, timeFormat } from './config'
 
 export default function Event({ event }) {
   const hasChanges = useHasChanges(event)
   return (
     <div className={styles.root} title={event.title} data-edits={hasChanges}>
       <div className={styles.titleWrapper}>
-        {hasChanges && (
+        {hasChanges && !hideWarnings && (
           <div className={styles.icon}>
             <WarningIcon />
           </div>

--- a/src/EventDialog.js
+++ b/src/EventDialog.js
@@ -12,7 +12,7 @@ import { useHasChanges } from './hooks'
 import Warning from './Warning'
 import { format } from 'date-fns'
 import User from './User'
-import { dateFormat, timeFormat, dialogTitle, showAuthor } from './config'
+import { dateFormat, timeFormat, dialogTitle, showAuthor, hideWarnings } from './config'
 import { getPublishedId } from 'part:@sanity/base/util/draft-utils'
 
 export default function EventDialog({ event, isOpen, onClose }) {
@@ -28,7 +28,7 @@ export default function EventDialog({ event, isOpen, onClose }) {
       padding="none"
     >
       <div className={styles.root}>
-        {hasChanges && (
+        {hasChanges && !hideWarnings && (
           <div className={styles.warning}>
             <Warning />
           </div>

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 import config from 'config:content-calendar'
 
-export const { types = [], calendar = {} } = config
+export const { types = [], calendar = {}, hideWarnings = false } = config
 
 export const {
   events = {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -3,11 +3,12 @@ import sanityClient from 'part:@sanity/base/client'
 import { parseISO, isAfter } from 'date-fns'
 import config from 'config:content-calendar'
 import delve from 'dlv'
+import { hideWarnings } from './config'
 
 let client = sanityClient
-if (typeof sanityClient.withConfig == "function") {
+if (typeof sanityClient.withConfig == 'function') {
   client = sanityClient.withConfig({
-    apiVersion: "v1"
+    apiVersion: 'v1',
   })
 }
 
@@ -67,7 +68,7 @@ export const useHasChanges = (event) => {
   const id = event.doc?._id || ''
   const [hasChanges, setHasChanges] = useState(false)
   const handleSetDraft = (document) => {
-    if (isAfter(parseISO(document._updatedAt), parseISO(event.scheduledAt))) {
+    if (!hideWarnings && isAfter(parseISO(document._updatedAt), parseISO(event.scheduledAt))) {
       setHasChanges(true)
     }
   }


### PR DESCRIPTION
The plugin is designed to throw warnings if a Document has been updated **after** the date it was Scheduled. And rightfully so because by design the plugin saves that Revision and the cloud function publishes that Revision.

But if your publishing workflow is something more like setting `isLive: true` on a Document, these warnings are just noise.

So a simple fix might be to add a `hideWarnings` option to the config, defaulting to `false` so it is opt-in.

Explainer:

https://www.loom.com/share/7e087f347964444bad121ac78c0191b1