### PR TITLE
Change method for filtering out default actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-content-calendar",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A Content Calendar for your Sanity Studio",
   "main": "build/index.js",
   "scripts": {

--- a/src/register.js
+++ b/src/register.js
@@ -32,12 +32,22 @@ function CustomPublishAction(params) {
   }
 }
 
-export function addActions({type}, actions) {
+export function addActions({type}, actions = []) {
   if (schedulingEnabled(type)) {
-    return [scheduleAction, unScheduleAction, CustomPublishAction, CustomDeleteAction].concat(
-      actions.filter(action => !['DeleteAction', 'PublishAction'].includes(action.name))
-    )
+    const pluginActions = [
+      scheduleAction,
+      unScheduleAction,
+      CustomPublishAction,
+      CustomDeleteAction
+    ]
+
+    const defaultActions = actions.filter(action => {
+      return action !== DeleteAction && action !== PublishAction
+    })
+
+    return [...pluginActions, ...defaultActions]
   }
+
   return actions
 }
 


### PR DESCRIPTION
Previous method (checking for .name) only worked during development.