### PR TITLE
feat: path to datetime field

### DIFF
--- a/src/scheduling.js
+++ b/src/scheduling.js
@@ -13,9 +13,15 @@ export function publishAt({draft}) {
   if (!draft) return null
   const typeConfig = config.types.find(t => t.type === draft._type)
   if (typeConfig) {
-    return draft[typeConfig.field]
+    return resolve(typeConfig.field, draft)
   }
   return null
+}
+
+function resolve(path, obj) {
+  return path.split('.').reduce(function(prev, curr) {
+      return prev ? prev[curr] : null
+  }, obj || self)
 }
 
 export function publishInFuture({draft}) {

--- a/src/scheduling.js
+++ b/src/scheduling.js
@@ -14,7 +14,7 @@ export function publishAt({draft}) {
   if (!draft) return null
   const typeConfig = config.types.find(t => t.type === draft._type)
   if (typeConfig) {
-    return delve(typeConfig.field, draft)
+    return delve(draft, typeConfig.field)
   }
   return null
 }

--- a/src/scheduling.js
+++ b/src/scheduling.js
@@ -4,6 +4,7 @@ import {isFuture, parseISO} from 'date-fns'
 import config from 'config:content-calendar'
 import userStore from 'part:@sanity/base/user'
 import client from './client'
+import delve from 'dlv'
 
 export function schedulingEnabled(type) {
   return !!config.types.find(t => t.type === type)
@@ -13,15 +14,9 @@ export function publishAt({draft}) {
   if (!draft) return null
   const typeConfig = config.types.find(t => t.type === draft._type)
   if (typeConfig) {
-    return resolve(typeConfig.field, draft)
+    return delve(typeConfig.field, draft)
   }
   return null
-}
-
-function resolve(path, obj) {
-  return path.split('.').reduce(function(prev, curr) {
-      return prev ? prev[curr] : null
-  }, obj || self)
 }
 
 export function publishInFuture({draft}) {


### PR DESCRIPTION
fix to enable having the datetime field in a sub-object. 

Using the method found at https://stackoverflow.com/a/45322101

i.e.:
```
{
  "types": [
    {
      "type": "post",
      "field": "meta.publishedAt",
      "titleField": "title"
    }
  ],
  "calendar": {
    "event": {
      "dateFormat": "MMMM, dd yyyy",
      "timeFormat": "hh:mm a",
      "showAuthor": "false"
    }
  },
  "filterWarnings": []
}
```